### PR TITLE
Explicitly specify 'sed' command to use

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,6 +2,7 @@
 
 export HELP2MAN=$(which true)
 export M4=m4
+export SED=$(which sed)
 
 export AR=$(basename $AR)
 export AS=$(basename $AS)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,16 +40,17 @@ test:
     - libtool --help
 
 about:
-  home: http://www.gnu.org/software/libtool/
+  home: https://www.gnu.org/software/libtool/
   license: GPL-2.0-or-later
+  license_family: GPL
   license_file: COPYING
   summary: The GNU Portable Library Tool
   description: |
     GNU libtool is a generic library support script. Libtool hides the
     complexity of using shared libraries behind a consistent, portable
     interface.
-  doc_url: http://www.gnu.org/software/libtool/manual/
-  dev_url: http://git.savannah.gnu.org/cgit/libtool.git
+  doc_url: https://www.gnu.org/software/libtool/manual/
+  dev_url: https://git.savannah.gnu.org/cgit/libtool.git
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     # - 0004-apple-silicon.patch
 
 build:
-  number: 1007
+  number: 1008
   skip: True  # [win]
   ignore_run_exports:
     - libstdcxx-ng


### PR DESCRIPTION
In some cases libtool's build system doesn't seem to be able to figure out which sed executable to use, resulting in a broken script, as on osx-arm64:

```
(/Users/anaconda/miniconda3/conda-bld/debug_1644432804334/_build_env) anaconda@static work % libtool
/Users/anaconda/miniconda3/conda-bld/debug_1644432804334/_build_env/bin/libtool: line 923: /usr/local/bin/gsed: No such file or directory
Usage: /Users/anaconda/miniconda3/conda-bld/debug_1644432804334/_build_env/bin/libtool [OPTION]... [MODE-ARG]...
```

Explicitly set the `SED` environment variable to override auto-detection with what's installed on the system.