### PR TITLE
Rebuild libtool 2.4.6 with autoconf 2.71

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - sk_test

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -xe
+
 export HELP2MAN=$(which true)
 export M4=m4
 export SED=$(which sed)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -29,7 +29,7 @@ make -j${CPU_COUNT} ${VERBOSE_AT}
 #if ! make check; then
 if false; then
   FAILURES=$(cat tests/testsuite.log | grep FAILED | wc -l | awk '{print $1}')
-  if [[ ${FAILURES} > 5 ]]; then
+  if [[ ${FAILURES} -gt 5 ]]; then
     echo "Expected 5 failures from the libtool testsuite due to cyclic dependency between libtool and autoconf/automake. Got ${FAILURES}"
     echo "See: http://lists.linuxfromscratch.org/pipermail/lfs-dev/2014-December/069805.html"
     echo "The expected failures are:"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://ftp-gnu-org.ip-connect.vn.ua/libtool/libtool-{{ version }}.tar.gz
+  url: https://ftpmirror.gnu.org/libtool/libtool-{{ version }}.tar.gz
   sha256: e3bd4d5d3d025a36c21dd6af7ea818a2afcd4dfc1ea5a17b39d7854bcd0c06e3
   patches:
     # From: https://bugs.debian.org/cgi-bin/bugreport.cgi?att=1;bug=557388;filename=link-as-needed.patch;msg=5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: http://ftpmirror.gnu.org/libtool/libtool-{{ version }}.tar.gz
+  url: https://ftp-gnu-org.ip-connect.vn.ua/libtool/libtool-{{ version }}.tar.gz
   sha256: e3bd4d5d3d025a36c21dd6af7ea818a2afcd4dfc1ea5a17b39d7854bcd0c06e3
   patches:
     # From: https://bugs.debian.org/cgi-bin/bugreport.cgi?att=1;bug=557388;filename=link-as-needed.patch;msg=5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     # - 0004-apple-silicon.patch
 
 build:
-  number: 1008
+  number: 1009
   skip: True  # [win]
   ignore_run_exports:
     - libstdcxx-ng
@@ -37,6 +37,7 @@ requirements:
 
 test:
   commands:
+    - libtool --version
     - libtool --help
 
 about:


### PR DESCRIPTION
Libtool is a **build** tool. It must be updated with other build tools:

`autoconf` https://github.com/AnacondaRecipes/autoconf-feedstock/pull/1 -> automake https://github.com/AnacondaRecipes/automake-feedstock/pull/5 -> **libtool**

Actions:

1. Add `set -xe` command (print shell command before executing it and exit immediately if it fails)
2. Bump build number to `1009 `
3. Add `libtool --version` to test/commands